### PR TITLE
Mine contract addresses

### DIFF
--- a/Dispatcher.hpp
+++ b/Dispatcher.hpp
@@ -46,6 +46,7 @@ class Dispatcher {
 			cl_kernel m_kernelInverse;
 			cl_kernel m_kernelInversePost;
 			cl_kernel m_kernelEnd;
+			cl_kernel m_kernelTransform;
 			cl_kernel m_kernelScore;
 
 			CLMemory<point> m_memPrecomp;

--- a/Mode.cpp
+++ b/Mode.cpp
@@ -78,6 +78,28 @@ Mode Mode::numbers() {
 	return r;
 }
 
+std::string Mode::transformKernel() const {
+	switch (this->target) {
+		case ADDRESS:
+			return "profanity_transform_identity";
+		case CONTRACT:
+			return "profanity_transform_contract";
+		default:
+			throw "No kernel for target";
+	}
+}
+
+std::string Mode::transformName() const {
+	switch (this->target) {
+		case ADDRESS:
+			return "Address";
+		case CONTRACT:
+			return "Contract";
+		default:
+			throw "No name for target";
+	}
+}
+
 Mode Mode::leadingRange(const cl_uchar min, const cl_uchar max) {
 	Mode r;
 	r.name = "leadingrange";

--- a/Mode.hpp
+++ b/Mode.hpp
@@ -4,6 +4,12 @@
 #include <string>
 #include <CL/cl.h>
 
+enum HashTarget {
+	ADDRESS,
+	CONTRACT,
+	HASH_TARGET_COUNT
+};
+
 class Mode {
 	private:
 		Mode();
@@ -21,7 +27,14 @@ class Mode {
 		static Mode numbers();
 
 		std::string name;
+
 		std::string kernel;
+
+		HashTarget target;
+		// kernel transform fn name
+		std::string transformKernel() const;
+		// Address, Contract, ...
+		std::string transformName() const;
 
 		cl_uchar data1[20];
 		cl_uchar data2[20];

--- a/help.hpp
+++ b/help.hpp
@@ -18,6 +18,8 @@ usage: ./profanity [OPTIONS]
     --matching <hex string> Score on hashes matching given hex string.
 
   Advanced modes:
+    --contract              Instead of account address, score the contract
+                            address created by the account's zeroth transaction.
     --leading-range         Scores on hashes leading with characters within
                             given range.
     --range                 Scores on hashes having characters within given
@@ -46,6 +48,7 @@ usage: ./profanity [OPTIONS]
     ./profanity --leading-range -m 0 -M 1
     ./profanity --leading-range -m 10 -M 12
     ./profanity --range -m 0 -M 1
+    ./profanity --contract --leading 0
 
   About:
     profanity is a vanity address generator for Ethereum that utilizes

--- a/keccak.cl
+++ b/keccak.cl
@@ -38,7 +38,6 @@ __constant int keccakf_piln[24] = {
 void sha3_keccakf(ethhash * const pHash)
 {
 	ulong * const st = &pHash->q;
-	pHash->d[16] ^= 0x01;
 	pHash->d[33] ^= 0x80000000;
 
     // variables

--- a/profanity.cl
+++ b/profanity.cl
@@ -506,7 +506,13 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 		h.b[i+2] = hash[i];
 	}
 	h.b[22] = 128;
+	// revert keccak size optimization
+	h.b[23] ^= 0x01;
+	h.d[16] ^= 0x01;
+
+
 	sha3_keccakf(&h);
+
 	pInverse[id].d[0] = h.d[3];
 	pInverse[id].d[1] = h.d[4];
 	pInverse[id].d[2] = h.d[5];

--- a/profanity.cl
+++ b/profanity.cl
@@ -488,6 +488,29 @@ void profanity_result_update( const size_t id, __global const uchar * const hash
 	}
 }
 
+__kernel void profanity_transform_identity(__global mp_number * const pInverse) {
+}
+
+__kernel void profanity_transform_contract(__global mp_number * const pInverse) {
+	const size_t id = get_global_id(0);
+	__global const uchar * const hash = pInverse[id].d;
+
+	// set up keccak(0xd6, 0x94, address, 0x80)
+	ethhash h;
+	h.b[0] = 214;
+	h.b[1] = 148;
+	for (int i = 0; i < 20; i++) {
+		h.b[i+2] = hash[i];
+	}
+	h.b[22] = 128;
+	sha3_keccakf(&h);
+	pInverse[id].d[0] = h.d[3];
+	pInverse[id].d[1] = h.d[4];
+	pInverse[id].d[2] = h.d[5];
+	pInverse[id].d[3] = h.d[6];
+	pInverse[id].d[4] = h.d[7];
+}
+
 __kernel void profanity_score_benchmark(__global mp_number * const pInverse, __global result * const pResult, __constant const uchar * const data1, __constant const uchar * const data2, const uchar scoreMax ) {
 	const size_t id = get_global_id(0);
 	__global const uchar * const hash = pInverse[id].d;

--- a/profanity.cl
+++ b/profanity.cl
@@ -497,6 +497,9 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 
 	// set up keccak(0xd6, 0x94, address, 0x80)
 	ethhash h;
+	for( int i = 0; i < 50; ++i ) {
+		h.d[i] = 0;
+	}
 	h.b[0] = 214;
 	h.b[1] = 148;
 	for (int i = 0; i < 20; i++) {

--- a/profanity.cl
+++ b/profanity.cl
@@ -495,11 +495,11 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 	const size_t id = get_global_id(0);
 	__global const uchar * const hash = pInverse[id].d;
 
-	// set up keccak(0xd6, 0x94, address, 0x80)
 	ethhash h;
 	for( int i = 0; i < 50; ++i ) {
 		h.d[i] = 0;
 	}
+	// set up keccak(0xd6, 0x94, address, 0x80)
 	h.b[0] = 214;
 	h.b[1] = 148;
 	for (int i = 0; i < 20; i++) {

--- a/profanity.cl
+++ b/profanity.cl
@@ -510,7 +510,6 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 	h.b[23] ^= 0x01;
 	h.d[16] ^= 0x01;
 
-
 	sha3_keccakf(&h);
 
 	pInverse[id].d[0] = h.d[3];

--- a/profanity.cl
+++ b/profanity.cl
@@ -464,6 +464,7 @@ __kernel void profanity_end(
 		h.d[i+8] = bswap32( p.y.d[MP_WORDS - 1 - i] );
 	}
 	
+	h.d[16] ^= 0x01; // length 64
 	sha3_keccakf(&h);
 
 	pInverse[id].d[0] = h.d[3];
@@ -506,10 +507,8 @@ __kernel void profanity_transform_contract(__global mp_number * const pInverse) 
 		h.b[i+2] = hash[i];
 	}
 	h.b[22] = 128;
-	// revert keccak size optimization
-	h.b[23] ^= 0x01;
-	h.d[16] ^= 0x01;
 
+	h.b[23] ^= 0x01; // length 23
 	sha3_keccakf(&h);
 
 	pInverse[id].d[0] = h.d[3];

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -151,7 +151,7 @@ int main(int argc, char * * argv) {
 		bool bNoCache = false;
 		size_t inverseSize = 1023;
 		size_t inverseMultiple = 16400;
-        bool bMineContract = false;
+		bool bMineContract = false;
 
 		argp.addSwitch('h', "help", bHelp);
 		argp.addSwitch('0', "benchmark", bModeBenchmark);
@@ -171,7 +171,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('n', "no-cache", bNoCache);
 		argp.addSwitch('i', "inverse-size", inverseSize);
 		argp.addSwitch('I', "inverse-multiple", inverseMultiple);
-        argp.addSwitch('c', "contract", bMineContract);
+		argp.addSwitch('c', "contract", bMineContract);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;
@@ -206,8 +206,14 @@ int main(int argc, char * * argv) {
 			std::cout << g_strHelp << std::endl;
 			return 0;
 		}
-
 		std::cout << "Mode: " << mode.name << std::endl;
+
+		if (bMineContract) {
+			mode.target = CONTRACT;
+		} else {
+			mode.target = ADDRESS;
+		}
+		std::cout << "Target: " << mode.transformName() << std:: endl;
 
 		std::vector<cl_device_id> vFoundDevices = getAllDevices();
 		std::vector<cl_device_id> vDevices;

--- a/profanity.cpp
+++ b/profanity.cpp
@@ -151,6 +151,7 @@ int main(int argc, char * * argv) {
 		bool bNoCache = false;
 		size_t inverseSize = 1023;
 		size_t inverseMultiple = 16400;
+        bool bMineContract = false;
 
 		argp.addSwitch('h', "help", bHelp);
 		argp.addSwitch('0', "benchmark", bModeBenchmark);
@@ -170,6 +171,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('n', "no-cache", bNoCache);
 		argp.addSwitch('i', "inverse-size", inverseSize);
 		argp.addSwitch('I', "inverse-multiple", inverseMultiple);
+        argp.addSwitch('c', "contract", bMineContract);
 
 		if (!argp.parse()) {
 			std::cout << "error: bad arguments, try again :<" << std::endl;


### PR DESCRIPTION
This implements https://github.com/johguse/profanity/issues/12.

Output of `./profanity.x64 --contract --leading 0`
```
Mode: leading
Target: Contract
Devices:
  GPU0: GeForce GTX 980 Ti, 6378094592 bytes available, 22 compute units (precompiled = no)

Initializing OpenCL...
  Creating context...OK
  Compiling kernel...OK
  Building program...OK
  Saving program...OK

Initializing devices...
  This can take a minute or two. The number of objects initialized on each
  device is equal to inverse-size * inverse-multiple. To lower
  initialization time (and memory footprint) I suggest lowering the
  inverse-multiple first. You can do this via the -I switch. Do note that
  this might negatively impact your performance.

  GPU0 initialized

Running...
  Always verify that a private key generated by this program corresponds to the
  public key printed by importing it to a wallet of your choice. This program
  like any software might contain bugs and it does by design cut corners to
  improve overall performance.


warning: local work size abandoned on GPU0
  Time:     1s Score:  6 Private: 0x0ba201a586bbb9e03f1038818ad773af9cf454a7e68d07dbf1f36d4a6f41b242 Contract: 0x000000ab27d7a39887f3e43a83e8de758361f2b7
Total: 7.250 MH/s - GPU0: 7.250 MH/s
Total: 10.512 MH/s - GPU0: 10.512 MH/s
  Time:     6s Score:  7 Private: 0x0ba201a586e32bac3f1038818ad773af9cf454a7e68d07dbf1f36d4a6f41b246 Contract: 0x0000000ea7d17d74ab407a28ca7624d1252d0356
Total: 11.599 MH/s - GPU0: 11.599 MH/s
Total: 12.142 MH/s - GPU0: 12.142 MH/s
Total: 12.468 MH/s - GPU0: 12.468 MH/s
Total: 12.684 MH/s - GPU0: 12.684 MH/s
Total: 12.838 MH/s - GPU0: 12.838 MH/s
Total: 12.955 MH/s - GPU0: 12.955 MH/s
Total: 13.044 MH/s - GPU0: 13.044 MH/s
```

Verified on rinkeby: https://rinkeby.etherscan.io/tx/0xea9a68f78b578dcfa6f479ab87d14bcee6436dc2913389f8c163b059551096db