### PR TITLE
Print hashrate to stderr

### DIFF
--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -383,7 +383,7 @@ void Dispatcher::printSpeed() {
 			++i;
 		}
 
-		std::cout << "Total: " << formatSpeed(speedTotal) << " -" << strGPUs << "\r" << std::flush;
+		std::cerr << "Total: " << formatSpeed(speedTotal) << " -" << strGPUs << "\r" << std::flush;
 		m_countPrint = 0;
 	}
 }

--- a/Dispatcher.cpp
+++ b/Dispatcher.cpp
@@ -383,7 +383,7 @@ void Dispatcher::printSpeed() {
 			++i;
 		}
 
-		std::cerr << "Total: " << formatSpeed(speedTotal) << " -" << strGPUs << "\r" << std::flush;
+		std::cerr << "Total: " << formatSpeed(speedTotal) << " -" << strGPUs << '\r' << std::flush;
 		m_countPrint = 0;
 	}
 }


### PR DESCRIPTION

#### Changes
Currently, hashrate is printed to stdout.
This prints the hashrate to stderr instead.
As a result, you can redirect output to a file without the file filling with hashrate over time.
Hashrate is still available for monitoring.
stderr displays alongside stdout in most terminals.
I haven't tested this on Windows.
Reviewers @johguse